### PR TITLE
feature/dockerize

### DIFF
--- a/.dockerignore
+++ b/.dockerignore
@@ -1,0 +1,2 @@
+.git
+node_modules

--- a/.gitignore
+++ b/.gitignore
@@ -1,3 +1,6 @@
+# ignore docker make flag
+.dockerbuild
+
 *.pyc
 *.pyo
 .coverage

--- a/Dockerfile
+++ b/Dockerfile
@@ -25,5 +25,9 @@ RUN npm install -g npm
 # install global task runners and phantomjs
 RUN npm install -g grunt-cli gulp phantomjs
 
+# install gulp sass requirements
+RUN apt-get install -y ruby
+RUN gem install sass
+
 VOLUME ['/src']
 WORKDIR /src

--- a/Dockerfile
+++ b/Dockerfile
@@ -1,0 +1,29 @@
+FROM debian
+MAINTAINER Ryan Grieve <ryan@rehabstudio.com>
+
+# update, upgrade and install base requisites
+RUN apt-get update && \
+    apt-get upgrade -y && \
+    apt-get install -y \
+        apt-transport-https \
+        inotify-tools \
+        build-essential \
+        sudo \
+        curl
+
+# install node from ppa
+RUN curl -sL https://deb.nodesource.com/setup | bash -
+RUN apt-get install -y nodejs
+
+# install phantomjs requirements
+RUN apt-get install -y \
+        libfreetype6 \
+        libfontconfig1
+
+# npm-ception: install latest from npm
+RUN npm install -g npm
+# install global task runners and phantomjs
+RUN npm install -g grunt-cli gulp phantomjs
+
+VOLUME ['/src']
+WORKDIR /src

--- a/Makefile
+++ b/Makefile
@@ -17,6 +17,7 @@ help:
 	@echo "\tmake docker-build - Trigger 'make build' via docker" 
 	@echo "\tmake docker-watch - Trigger 'make watch' via docker" 
 	@echo "\tmake docker-test - Trigger 'make test' via docker" 
+	@echo "\tmake docker-shell - Launch `bash` in a new container for debugging" 
 
 default: help
 
@@ -111,4 +112,4 @@ docker-shell: .dockerbuild
 	docker run -ti --rm -v $(CURDIR):/src $(IMAGE_NAME) bash
 
 # makefile ettiquette; mark rules without on-disk targets as PHONY
-.PHONY: default help setup fe-setup build watch test docker-build docker-watch docker-test
+.PHONY: default help setup fe-setup build watch test docker-build docker-watch docker-test docker-shell

--- a/Makefile
+++ b/Makefile
@@ -1,6 +1,114 @@
-help:
-	@echo "fe-setup - Installs node dependencies and triggers compilation of build files."
+# can be overridden at runtime eg. `make build runner=grunt`
+runner=gulp
 
-fe-setup:
+help:
+	@echo "fe-skeleton"
+	@echo ""
+	@echo "The following commands are available:"
+	@echo ""
+	@echo "\tmake setup - Installs node dependencies and requisites for build"
+	@echo "\tmake build - Triggers a compilation via preferred task runner"
+	@echo "\tmake watch - Triggers a watcher via preferred task runner"
+	@echo "\tmake test - Triggers test run via preferred task runner"
+	@echo ""
+	@echo ""
+	@echo "Docker based building is also available:"
+	@echo ""
+	@echo "\tmake docker-build - Trigger 'make build' via docker" 
+	@echo "\tmake docker-watch - Trigger 'make watch' via docker" 
+	@echo "\tmake docker-test - Trigger 'make test' via docker" 
+
+default: help
+
+build: node_modules
+	$(runner) build;
+
+watch: node_modules
+	$(runner);
+
+test: node_modules
+	$(runner) test;
+
+# just install node_modules, also callable as `make node_modules`
+setup: node_modules
+
+# backwards compatibility
+fe-setup: build
+
+# this only runs if the modification date of `package.json` is more recent
+# than the modification date of `node_modules`, `touch $@` updates the
+# modification date of `node_modules` when done.
+node_modules: package.json
+	npm cache clean;
 	npm install;
-	gulp build;
+	touch $@
+
+
+# Variables for docker based building
+IMAGE_NAME = fe-skeleton
+BASE_CONTAINER_NAME = $(IMAGE_NAME)-$(runner)
+
+# use a target flag file (.dockerbuild) so image is only rebuilt when
+# Dockerfile has been changed more recently than last build
+.dockerbuild: Dockerfile
+	-docker rm $(BASE_CONTAINER_NAME)-build
+	-docker rm $(BASE_CONTAINER_NAME)-watch
+	-docker rm $(BASE_CONTAINER_NAME)-test
+	docker build -t $(IMAGE_NAME) .
+	touch $@
+
+# Here we check if a container with the correct name already exists and if
+# it does we run it again. Otherwise we run a new one and have it call
+# `make run runner=$(runner)`
+docker-build: .dockerbuild
+	@EXISTS=$$(docker ps -a | grep "$(BASE_CONTAINER_NAME)-build" | awk '{ print $$1 }'); \
+	if [ $$EXISTS ]; then \
+		echo "Reusing existing container..."; \
+		docker start -ai $$EXISTS; \
+	else \
+		echo "Running a new container..."; \
+		docker run \
+			-ti \
+			--name $(BASE_CONTAINER_NAME)-build \
+			-v $(CURDIR):/src \
+			$(IMAGE_NAME) \
+			make build runner=$(runner); \
+	fi
+
+# Same as above but running `make watch runner=$(runner)`
+docker-watch: .dockerbuild
+	@EXISTS=$$(docker ps -a | grep "$(BASE_CONTAINER_NAME)-watch" | awk '{ print $$1 }'); \
+	if [ $$EXISTS ]; then \
+		echo "Reusing existing container..."; \
+		docker start -ai $$EXISTS; \
+	else \
+		echo "Running a new container..."; \
+		docker run \
+			-ti \
+			--name $(BASE_CONTAINER_NAME)-watch \
+			-v $(CURDIR):/src \
+			$(IMAGE_NAME) \
+			make watch runner=$(runner); \
+	fi
+
+# Same as above but running `make test runner=$(runner)`
+docker-test: .dockerbuild
+	@EXISTS=$$(docker ps -a | grep "$(BASE_CONTAINER_NAME)-test" | awk '{ print $$1 }'); \
+	if [ $$EXISTS ]; then \
+		echo "Reusing existing container..."; \
+		docker start -ai $$EXISTS; \
+	else \
+		echo "Running a new container..."; \
+		docker run \
+			-ti \
+			--name $(BASE_CONTAINER_NAME)-test \
+			-v $(CURDIR):/src \
+			$(IMAGE_NAME) \
+			make test runner=$(runner); \
+	fi
+
+docker-shell: .dockerbuild
+	docker run -ti --rm -v $(CURDIR):/src $(IMAGE_NAME) bash
+
+# makefile ettiquette; mark rules without on-disk targets as PHONY
+.PHONY: default help setup fe-setup build watch test docker-build docker-watch docker-test

--- a/Makefile
+++ b/Makefile
@@ -53,6 +53,9 @@ BASE_CONTAINER_NAME = $(IMAGE_NAME)-$(runner)
 	docker build -t $(IMAGE_NAME) .
 	touch $@
 
+# default docker command
+cmd=build
+
 # Here we check if a container with the correct name already exists and if
 # it does we run it again. Otherwise we run a new one and have it call
 # `make $(cmd) runner=$(runner)`


### PR DESCRIPTION
Dockerizing the build process to allow building and watching without the need for system-wide node or npm. This is fully backwards compatible and does not interfere with the vanilla build process in anyway.

The Makefile has been updated appropriately, whilst maintaining previous functionality, and has the added bonus now of using make targets to allow any runner task (e.g. `make lint`) to be called, and automatically call `npm install` only if `package.json` has changed since the last time `node_modules` was modified.

Docker functionality is used by calling `make docker cmd=<task>` where `<task>` is the gulp/grunt task to be run. Additionally the `runner` variable can be used to change the task runner, e.g. `make build runner=grunt` or `make docker cmd=build runner=grunt`.