### PR TITLE
Updating prefixer object literal path removing browsers key  

### DIFF
--- a/run/tasks/styles/gulp.js
+++ b/run/tasks/styles/gulp.js
@@ -7,7 +7,7 @@
  *  https://github.com/Metrime/gulp-autoprefixer/issues/3
  *
  *  Example Usage:
- *  grunt styles
+ *  gulp styles
  */
 
 var gulp = require('gulp'),
@@ -66,7 +66,7 @@ function _processBundle(resolve, reject) {
     var stream = gulp.src(sourcePath)
         .pipe(plumber())
         .pipe(sass(combinedSassSettings))
-        .pipe(prefix(common.autoPrefixSettings.browsers), { map: false })
+        .pipe(prefix(common.autoPrefixSettings), { map: false })
         .pipe(gulp.dest(globalSettings.destPath + common.outputFolder));
 
     // Whenever the stream finishes, resolve or reject the deferred accordingly.


### PR DESCRIPTION
Updating prefixer common path, removing .browsers as this makes the path too specific and ignoring any other prefixer settings within the settings object.