### PR TITLE
Use node-sass over ruby-sass.

### DIFF
--- a/README.md
+++ b/README.md
@@ -30,13 +30,7 @@ git push origin master
 You can also copy the files and folders of this repository into your own, excluding the `.git` folder so it doesn't overwrite your own. Be aware that this will not preserve any git history of this repo.
 
 ## Installation
-Style sheet compilation involves using the `sass` Ruby gem. This needs to be installed prior to running the setup method ahead. Assuming you have Ruby on your system, the gem can be installed with the following command:
-
-```
-gem install sass;
-```
-
-Once you have done this, you're ready to start the overall tooling installation via the `Makefile` method below:
+The entire toolchain is node based so ensure you are using a stable version of node such as `0.10.x` or `0.12.x`. Also ensure your version of NPM is at least `2.6.x`. Once you have met these requirements, you're ready to start the overall tooling installation via the `Makefile` method below:
 
 ```
 make fe-setup;

--- a/package.json
+++ b/package.json
@@ -35,7 +35,7 @@
         "jshint-stylish": "^1.0.1",
         "gulp-wrap": "^0.11.0",
         "gulp-jshint": "^1.9.2",
-        "gulp-ruby-sass": "^0.7.1",
+        "gulp-sass": "^1.3.3",
         "gulp-autoprefixer": "2.1.0",
         "gulp-imagemin": "^2.2.1",
         "gulp-handlebars": "^3.0.1",

--- a/run/tasks/styles/_common.js
+++ b/run/tasks/styles/_common.js
@@ -18,11 +18,9 @@ module.exports = {
     // Where to place the built bundles. Is prefixed with `destPath` from global settings.
     outputFolder: './css/',
 
-    // Settings for Ruby Sass gem.
+    // Settings to be passed through to gulp-sass and node-sass.
     sassSettings: {
-        noCache: true,
-        'sourcemap=none': true, // Hack until gulp-ruby-sass v1.0 is released: http://bit.ly/1yolgzq
-        style: 'compact'
+        outputStyle: 'compressed'
     },
 
     // Settings for AutoPrefixer.

--- a/run/tasks/styles/gulp.js
+++ b/run/tasks/styles/gulp.js
@@ -3,6 +3,14 @@
 /**
  *  Compiles, minifies and prefixes SASS.
  *
+ *  Until Node-Sass starts using libsass 3.2 sourcemaps are fundamentally broken:
+ *  https://github.com/sass/node-sass/issues/619
+ *  https://github.com/sass/libsass/issues/837
+ *  https://github.com/sass/libsass/pull/910
+ *
+ *  libsass 3.2 progress:
+ *  https://github.com/sass/libsass/milestones/3.2
+ *
  *  Example Usage:
  *  gulp styles
  */

--- a/run/tasks/styles/gulp.js
+++ b/run/tasks/styles/gulp.js
@@ -6,6 +6,7 @@
  *  Until Node-Sass starts using libsass 3.2 sourcemaps are fundamentally broken:
  *  https://github.com/sass/node-sass/issues/619
  *  https://github.com/sass/libsass/issues/837
+ *  https://github.com/sass/libsass/pull/792
  *  https://github.com/sass/libsass/pull/910
  *
  *  libsass 3.2 progress:

--- a/run/tasks/styles/gulp.js
+++ b/run/tasks/styles/gulp.js
@@ -3,9 +3,6 @@
 /**
  *  Compiles, minifies and prefixes SASS.
  *
- *  Note: Sourcemaps are WIP in the AutoPrefixer.
- *  https://github.com/Metrime/gulp-autoprefixer/issues/3
- *
  *  Example Usage:
  *  gulp styles
  */
@@ -15,7 +12,7 @@ var gulp = require('gulp'),
     globalSettings = require('../../_global'),
     _ = require('underscore'),
     plumber = require('gulp-plumber'),
-    sass = require('gulp-ruby-sass'),
+    sass = require('gulp-sass'),
     prefix = require('gulp-autoprefixer');
 
 gulp.task('styles', function(taskDone) {
@@ -52,21 +49,14 @@ gulp.task('styles', function(taskDone) {
 function _processBundle(resolve, reject) {
     var self = this;
 
-    // Merging shared settings with some Gulp/Bundle specific settings.
-    // Container is important when building more than one bundle.
-    var combinedSassSettings = _.extend({
-        sourcemapPath: './src',
-        container: 'sass-tmp-container-' + self.index
-    }, common.sassSettings);
-
     // Generating path to source file.
     var sourcePath = self.srcPath + self.fileName + '.scss';
 
     // Compile SASS into CSS then prefix and save.
     var stream = gulp.src(sourcePath)
         .pipe(plumber())
-        .pipe(sass(combinedSassSettings))
-        .pipe(prefix(common.autoPrefixSettings), { map: false })
+        .pipe(sass(common.sassSettings))
+        .pipe(prefix(common.autoPrefixSettings))
         .pipe(gulp.dest(globalSettings.destPath + common.outputFolder));
 
     // Whenever the stream finishes, resolve or reject the deferred accordingly.


### PR DESCRIPTION
The performance gains listed in #11 are reason enough to change, and also given the fact that `node-sass` is more stable than ever. A nice added bonus is that we'll lose our Ruby dependency.

This PR effectively fixes #11.