### PR TITLE
Removing nested requires in scripts task

### DIFF
--- a/package.json
+++ b/package.json
@@ -36,12 +36,12 @@
         "gulp-autoprefixer": "2.1.0",
         "gulp-imagemin": "^2.2.1",
         "browserify": "^9.0.3",
-        "gulp-extract-sourcemap": "^0.1.1",
+        "gulp-extract-sourcemap": "^0.1.2",
         "gulp-filter": "^2.0.2",
-        "gulp-uglifyjs": "^0.6.0",
+        "gulp-uglifyjs": "^0.6.1",
         "handlebars": "^3.0.0",
         "hbsfy": "^2.2.1",
         "vinyl-buffer": "^1.0.0",
-        "vinyl-source-stream": "^1.0.0"
+        "vinyl-source-stream": "^1.1.0"
     }
 }

--- a/run/tasks/styles/gulp.js
+++ b/run/tasks/styles/gulp.js
@@ -24,6 +24,12 @@ var gulp = require('gulp'),
     sass = require('gulp-sass'),
     prefix = require('gulp-autoprefixer');
 
+/**
+ *  Overall function that will cycle through each of the styles bundles
+ *  and once they're all completed, trigger the completion of the gulp task.
+ *
+ *  @param {object} taskDone - Gulp task callback method.
+ */
 gulp.task('styles', function(taskDone) {
     var promises = [];
 


### PR DESCRIPTION
Now that we have removed RequireJS from the build, there is no need to have nested requires within the browserify sub-functions. For some reason, moving these requires up to the top level results in much faster compilation speeds upon recurring tasks / watch-triggered runs.

My only guess is that node is somehow caching the files that it's previously loaded and somehow retaining this cache throughout recurring executions. Speed differences are listed below:

Nested Requires:
```
[10:33:33] Finished 'scripts' after 1.48 s
[10:33:36] Finished 'scripts' after 1.52 s
[10:33:38] Finished 'scripts' after 1.6 s
[10:33:41] Finished 'scripts' after 1.51 s
[10:33:43] Finished 'scripts' after 1.52 s
```
Average after 5 runs is 1526ms

Top-level Requires:
```
[10:34:42] Finished 'scripts' after 859 ms
[10:34:45] Finished 'scripts' after 850 ms
[10:34:47] Finished 'scripts' after 858 ms
[10:34:49] Finished 'scripts' after 760 ms
[10:34:52] Finished 'scripts' after 847 ms
```
Average after 5 runs is 847ms

The top-level requires are up to **55%** faster.