### PR TITLE
Update sourcemap and uglify implementations

### DIFF
--- a/package.json
+++ b/package.json
@@ -29,6 +29,7 @@
 
         "gulp": "^3.8.11",
         "gulp-plumber": "^0.6.6",
+        "gulp-sourcemaps": "^1.5.0",
         "gulp-jscs": "^1.4.0",
         "gulp-jshint": "^1.9.2",
         "jshint-stylish": "^1.0.1",
@@ -36,9 +37,7 @@
         "gulp-autoprefixer": "2.1.0",
         "gulp-imagemin": "^2.2.1",
         "browserify": "^9.0.3",
-        "gulp-extract-sourcemap": "^0.1.2",
-        "gulp-filter": "^2.0.2",
-        "gulp-uglifyjs": "^0.6.1",
+        "gulp-uglify": "^1.1.0",
         "handlebars": "^3.0.0",
         "hbsfy": "^2.2.1",
         "vinyl-buffer": "^1.0.0",

--- a/run/_global.js
+++ b/run/_global.js
@@ -9,16 +9,30 @@ module.exports = {
      */
     destPath: './dist/',
 
-    /**
-     *  Sourcemaps are built externally but there is two choices. Source
-     *  files can be embedded inside the map itself, or, the source files
-     *  can be referenced by the map and loaded whenever you try to click
-     *  line numbers in your dev tools.
-     *
-     *  Potential Values:
-     *  'External_EmbeddedFiles'
-     *  'External_ReferencedFiles'
-     */
-    sourcemapType: 'External_ReferencedFiles'
+    sourcemapOptions: {
+
+        /**
+         *  Sourcemaps are built externally but there is two choices. Source
+         *  files can be embedded inside the map itself, or, the source files
+         *  can be referenced by the map and loaded whenever you try to click
+         *  line numbers in your dev tools.
+         *
+         *  Potential Values:
+         *  'External_EmbeddedFiles'
+         *  'External_ReferencedFiles'
+         */
+        type: 'External_ReferencedFiles'
+
+        /**
+         *  Sets the path where source files are hosted. This path is relative
+         *  to the source map. If you have sources in different subpaths, an
+         *  absolute path (from the domain root) pointing to the source file
+         *  root is recommended.
+         *
+         *  NOTE: This only needs to be set for 'External_ReferencedFiles' maps.
+         */
+        sourceRoot: '/'
+
+    }
 
 };

--- a/run/_global.js
+++ b/run/_global.js
@@ -2,8 +2,23 @@
 
 module.exports = {
 
-    // Where built output (CSS, JS, fonts, images) should be stored on the filesystem.
-    // Can either be absolute path or relative path to gulpfile.
-    destPath: './dist/'
+    /**
+     *  Where built output (CSS, JS, HTML, fonts, images) should be stored
+     *  on the filesystem. Can either be an absolute path or relative path
+     *  to the location of the gulpfile.
+     */
+    destPath: './dist/',
+
+    /**
+     *  Sourcemaps are built externally but there is two choices. Source
+     *  files can be embedded inside the map itself, or, the source files
+     *  can be referenced by the map and loaded whenever you try to click
+     *  line numbers in your dev tools.
+     *
+     *  Potential Values:
+     *  'External_EmbeddedFiles'
+     *  'External_ReferencedFiles'
+     */
+    sourcemapType: 'External_ReferencedFiles'
 
 };

--- a/run/tasks/scripts/_common.js
+++ b/run/tasks/scripts/_common.js
@@ -22,12 +22,6 @@ module.exports = {
     // Where to place the built bundles. Is prefixed with `destPath` from global settings.
     outputFolder: './js/',
 
-    // Settings that get fed into UglifyJS.
-    uglifySourceMapSettings: {
-        root: '/', // Sets sourceRoot in source map file.
-        orig: null // Updated during inline sourcemap extraction.
-    },
-
     // Settings for UglifyJS2.
     uglifySettings: {
         compress: {

--- a/run/tasks/scripts/gulp.js
+++ b/run/tasks/scripts/gulp.js
@@ -64,9 +64,9 @@ function _processBundle(resolve, reject) {
 
     // Apply particular options if global settings dictate source files should be referenced inside sourcemaps.
     var sourcemapOptions = {};
-    if (globalSettings.sourcemapType === 'External_ReferencedFiles') {
+    if (globalSettings.sourcemapOptions.type === 'External_ReferencedFiles') {
         sourcemapOptions.includeContent = false;
-        sourcemapOptions.sourceRoot = '/';
+        sourcemapOptions.sourceRoot = globalSettings.sourcemapOptions.sourceRoot;
     }
 
     // Creating a browserify instance / stream.


### PR DESCRIPTION
The accepted convention in gulp plugins on how to handle sourcemaps is via a popular plugin called `gulp-sourcemaps`. We couldn't use these until recently, as the currently uglification plugin `gulp-uglifyjs` doesn't work well with `gulp-sourcemaps`.

This uglification plugin has just became blacklisted for not doing things "the gulp way". I've found an alternative that happens to also play very well with `gulp-sourcemaps`.

This PR swaps our sourcemaps implementation to use the now commonly accepted `gulp-sourcemaps` plugin, as well as updates our uglifying to `gulp-uglify`. Another added result of this refactoring is that we have one fewer node packages than before and plays into an upcoming PR where we will bring sourcemaps to stylesheets using the same `gulp-sourcemap` plugin.

There are new global settings that cover sourcemap options where you can choose to have external sourcemaps with embedded source files, or external sourcemaps with source file references.