### PR TITLE
Linter should fail on JS errors.

### DIFF
--- a/run/tasks/lint/gulp.js
+++ b/run/tasks/lint/gulp.js
@@ -16,5 +16,6 @@ var gulp = require('gulp'),
 gulp.task('lint', function() {
     return gulp.src(common.buildSources(args.filePath))
         .pipe(jshint())
-        .pipe(jshint.reporter('jshint-stylish'));
+        .pipe(jshint.reporter('jshint-stylish'))
+        .pipe(jshint.reporter('fail'));
 });


### PR DESCRIPTION
Currently the linter isn't erroring whenever warnings or errors are found in JS source code. This means the process exits with a `0` (success) and if the linter is in a gulp pipeline it won't stop the execution of anything after it.

This PR sees that the linter method correctly errors when a warning or error in a JS source file is found, and exits the process with the correct code.