### PR TITLE
Adding blank dependencies to package.json

### DIFF
--- a/package.json
+++ b/package.json
@@ -12,6 +12,8 @@
         "Anthony Hastings <anthony@rehabstudio.com>",
         "Neil McCallion <neil@rehabstudio.com>"
     ],
+    "dependencies": {
+    },
     "devDependencies": {
         "yargs": "^3.3.1",
         "es6-promise": "^2.0.1",


### PR DESCRIPTION
This should encourage people to keep their build tool depenencies (`"devDependencies"`) and their project dependencies separate.