### PR TITLE
Adding a webserver task

### DIFF
--- a/README.md
+++ b/README.md
@@ -134,6 +134,9 @@ Analyzes JavaScript source files to ensure their coding style adheres to a parti
 ### `lint`
 Examines JavaScript source files for errors and code that doesn't conform to the specified standards.
 
+### `server`
+Hosts the `dist` via a node webserver.
+
 ### `scripts`
 Compiles source files into minified, uglified payloads.
 

--- a/README.md
+++ b/README.md
@@ -135,7 +135,7 @@ Analyzes JavaScript source files to ensure their coding style adheres to a parti
 Examines JavaScript source files for errors and code that doesn't conform to the specified standards.
 
 ### `server`
-Hosts the `dist` via a node webserver.
+Hosts the `dist` folder via a node webserver.
 
 ### `scripts`
 Compiles source files into minified, uglified payloads.

--- a/package.json
+++ b/package.json
@@ -42,6 +42,7 @@
         "gulp-uglify": "^1.1.0",
         "handlebars": "^3.0.0",
         "hbsfy": "^2.2.1",
+        "gulp-webserver": "^0.9.0",
         "vinyl-buffer": "^1.0.0",
         "vinyl-source-stream": "^1.1.0",
         "merge-stream": "0.1.7"

--- a/run/tasks/server/_common.js
+++ b/run/tasks/server/_common.js
@@ -1,0 +1,10 @@
+'use strict';
+
+module.exports = {
+    // Settings for gulp-webserver.
+    webserverSettings: {
+        port: 4321,
+        https: false,
+        open: true
+    }
+};

--- a/run/tasks/server/gulp.js
+++ b/run/tasks/server/gulp.js
@@ -1,0 +1,18 @@
+'use strict';
+
+/**
+ *  Hosts the `dist` folder on a specific port.
+ *
+ *  Example Usage:
+ *  gulp server
+ */
+
+var gulp = require('gulp'),
+    common = require('./_common'),
+    globalSettings = require('../../_global'),
+    webserver = require('gulp-webserver');
+
+gulp.task('server', function() {
+    return gulp.src(globalSettings.destPath)
+               .pipe(webserver(common.webserverSettings));
+});


### PR DESCRIPTION
Adding a webserver allows us to host our `dist` folder on a specific port which'll help when prototyping or examples.