### PR TITLE
Karma + Gulp: Exit Codes

### DIFF
--- a/run/tasks/test/gulp.js
+++ b/run/tasks/test/gulp.js
@@ -24,7 +24,7 @@ gulp.task('test', function(done) {
         karmaSettings.singleRun = false;
     }
 
-    karma.server.start(karmaSettings, function() {
-        done();
-    });
+    // Karma will start the tests and trigger the callback with
+    // the correct exit code (0 for success, 1 for error).
+    karma.server.start(karmaSettings, done);
 });


### PR DESCRIPTION
Ensuring that gulp is given the exit code from karma, so that the gulp task exits with the same code.

Example for a failing test suite:
```
gulp test;
echo $?;
```