### PR TITLE
Updating gulp-sass settings.

### DIFF
--- a/run/tasks/styles/_common.js
+++ b/run/tasks/styles/_common.js
@@ -20,7 +20,8 @@ module.exports = {
 
     // Settings to be passed through to gulp-sass and node-sass.
     sassSettings: {
-        outputStyle: 'compressed'
+        outputStyle: 'compressed',
+        errLogToConsole: true
     },
 
     // Settings for AutoPrefixer.


### PR DESCRIPTION
Errors during watch currently break. This will stop watch from stopping.