### PR TITLE
Updated task warnings and errors

### DIFF
--- a/run/index.js
+++ b/run/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Loading dependencies.
-var chalk = require('chalk');
-
 // Adding promises to nodes global scope.
 require('es6-promise').polyfill();
 
@@ -28,7 +25,7 @@ module.exports = function(runner) {
         modulesToLoad = loadingOverrides[desiredModule] || [desiredModule]; // Check for module loading overrides.
 
     modulesToLoad.forEach(function(module) {
-        console.log(chalk.bgYellow.gray(' FE Skeleton: Loading module - ' + module));
+        console.log(' FE Skeleton: Loading module - ' + module);
         require('./tasks/' + module + '/' + runner + '.js');
     });
 };

--- a/run/tasks/build/gulp.js
+++ b/run/tasks/build/gulp.js
@@ -10,11 +10,22 @@
  */
 
 var gulp = require('gulp'),
+    chalk = require('chalk'),
     args = require('yargs').argv,
     globalSettings = require('../../_global'),
+    scriptSettings = require('../scripts/_common'),
+    styleSettings = require('../styles/_common'),
     mergeStream = require('merge-stream');
 
 gulp.task('build', ['styles', 'scripts'], function() {
+    if (scriptSettings.bundles.length === 0) {
+        console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no script bundles defined.'));
+    }
+
+    if (styleSettings.bundles.length === 0) {
+        console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no style bundles defined.'));
+    }
+
     var htmlStream = gulp.src(['./html/**/*.html'])
                          .pipe(gulp.dest(globalSettings.destPath));
 

--- a/run/tasks/server/gulp.js
+++ b/run/tasks/server/gulp.js
@@ -8,11 +8,21 @@
  */
 
 var gulp = require('gulp'),
+    chalk = require('chalk'),
+    fs = require('fs'),
     common = require('./_common'),
     globalSettings = require('../../_global'),
     webserver = require('gulp-webserver');
 
 gulp.task('server', function() {
+    var distFolderExists = false;
+    try { distFolderExists = fs.statSync(globalSettings.destPath); } catch(e) {}
+
+    if (!distFolderExists) {
+        console.log(chalk.bgRed.white(' FE Skeleton: Cannot run server. Dist folder doesn\'t exist.'));
+        return process.exit(1);
+    }
+
     return gulp.src(globalSettings.destPath)
                .pipe(webserver(common.webserverSettings));
 });


### PR DESCRIPTION
Updating the code base with some extra warnings on a few our of methods.

1) `build` will now warn if it's being called without any script or style bundles being defined.
2) `server` will error and exit if it's being called without a `dist` folder existing to host.

Fixes #43.