### PR TITLE
JSDoc formatting is now validated.

### DIFF
--- a/.jscsrc
+++ b/.jscsrc
@@ -90,5 +90,22 @@
     "requireSpaceBeforeObjectValues": true,
     "requireCapitalizedConstructors": true,
     "requireDotNotation": true,
-    "validateParameterSeparator": ", "
+    "validateParameterSeparator": ", ",
+    "jsDoc": {
+        "checkAnnotations": {
+            "preset": "closurecompiler",
+            "extra": {
+                "ngInject": false
+            }
+        },
+        "checkParamNames": true,
+        "requireParamTypes": true,
+        "checkRedundantParams": true,
+        "checkReturnTypes": true,
+        "checkRedundantReturns": true,
+        "requireReturnTypes": true,
+        "checkTypes": "capitalizedNativeCase",
+        "checkRedundantAccess": true,
+        "requireNewlineAfterDescription": true
+    }
 }


### PR DESCRIPTION
Pushing something we've done on Miyagi to the JSCS rules which ensures that if there's function documentation, that it's actually useful, formatted correctly, and describes parameters / returns correctly.