### PR TITLE
Modularizing HTML feature so it can be watched.

### DIFF
--- a/run/index.js
+++ b/run/index.js
@@ -8,9 +8,9 @@ require('es6-promise').polyfill();
  *  need to load modules other than themselves to function.
  */
 var loadingOverrides = {
-    'watch': ['styles', 'scripts', 'watch'],
-    'build': ['styles', 'scripts', 'build'],
-    'default': ['styles', 'scripts', 'build', 'default']
+    'watch': ['html', 'styles', 'scripts', 'watch'],
+    'build': ['html', 'styles', 'scripts', 'build'],
+    'default': ['html', 'styles', 'scripts', 'build', 'default']
 };
 
 /**

--- a/run/tasks/build/index.js
+++ b/run/tasks/build/index.js
@@ -17,7 +17,7 @@ var gulp = require('gulp'),
     styleSettings = require('../styles/_common'),
     mergeStream = require('merge-stream');
 
-gulp.task('build', ['styles', 'scripts'], function() {
+gulp.task('build', ['html', 'styles', 'scripts'], function() {
     if (scriptSettings.bundles.length === 0) {
         console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no script bundles defined.'));
     }
@@ -26,11 +26,8 @@ gulp.task('build', ['styles', 'scripts'], function() {
         console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no style bundles defined.'));
     }
 
-    var htmlStream = gulp.src(['./html/**/*.html'])
-                         .pipe(gulp.dest(globalSettings.destPath));
-
     var assetStream = gulp.src(['./fonts/**/!(dir.txt)', './img/**/!(dir.txt)'], { base: './' })
                           .pipe(gulp.dest(globalSettings.destPath));
 
-    return mergeStream(htmlStream, assetStream);
+    return mergeStream(assetStream);
 });

--- a/run/tasks/html/_common.js
+++ b/run/tasks/html/_common.js
@@ -1,0 +1,5 @@
+'use strict';
+
+module.exports = {
+    srcPaths: ['./html/**/*.html']
+};

--- a/run/tasks/html/index.js
+++ b/run/tasks/html/index.js
@@ -1,0 +1,22 @@
+'use strict';
+
+/**
+ *  Moves HTML assets (maintaining folder structure) to
+ *  the global `destPath` directory.
+ *
+ *  Example Usage:
+ *  gulp html
+ */
+
+var gulp = require('gulp'),
+    common = require('./_common'),
+    chalk = require('chalk'),
+    globalSettings = require('../../_global');
+
+gulp.task('html', function() {
+    return gulp.src(common.srcPaths)
+        .pipe(gulp.dest(globalSettings.destPath))
+        .on('finish', function() {
+            console.log(chalk.bgGreen.white(' FE Skeleton: HTML assets moved.'));
+        });
+});

--- a/run/tasks/watch/_common.js
+++ b/run/tasks/watch/_common.js
@@ -4,6 +4,7 @@ var _ = require('underscore');
 
 module.exports = {
     watchPaths: {
+        html: ['./html/**/*.html'],
         styles: ['./css/libs/**/*.scss', './css/src/**/*.scss'],
         scripts: ['./js/libs/**/*.js', './js/src/**/*.js', '!./js/src/templates/**/*.js'],
         templates: ['./js/src/templates/**/*.hbs']

--- a/run/tasks/watch/index.js
+++ b/run/tasks/watch/index.js
@@ -18,6 +18,10 @@ var gulp = require('gulp'),
 
 gulp.task('watch', function() {
     var watchFunctions = {
+        html: function() {
+            console.log(chalk.bgYellow.gray(' FE Skeleton: Watching HTML.'));
+            gulp.watch(common.watchPaths.html, ['html']);
+        },
         styles: function() {
             console.log(chalk.bgYellow.gray(' FE Skeleton: Watching styles.'));
             gulp.watch(common.watchPaths.styles, ['styles']);


### PR DESCRIPTION
One of the biggest bugbears with the current code base is that HTML assets can only be moved into the `destPath` whenever running `gulp build`. This change modularises the HTML assets so they can be watched via `gulp watch`. Fixes #41.