### PR TITLE
Lint / JSCS: Output file names.

### DIFF
--- a/package.json
+++ b/package.json
@@ -31,6 +31,7 @@
     "es6-promise": "^2.3.0",
     "underscore": "^1.8.3",
     "gulp": "^3.9.0",
+    "gulp-debug": "^2.1.0",
     "gulp-plumber": "^1.0.1",
     "gulp-sourcemaps": "^1.5.2",
     "gulp-jscs": "^2.0.0",

--- a/run/tasks/jscs/index.js
+++ b/run/tasks/jscs/index.js
@@ -22,11 +22,13 @@ var gulp = require('gulp'),
     args = require('yargs').argv,
     chalk = require('chalk'),
     common = require('./_common'),
+    debug = require('gulp-debug'),
     jscs = require('gulp-jscs');
 
 gulp.task('jscs', function() {
     return gulp.src(common.buildSources(args.filePath))
         .pipe(jscs())
+        .pipe(debug({ title: 'JSCS:' }))
         .on('error', function() {
             if (args.viaCommit) {
                 setTimeout(function() {

--- a/run/tasks/lint/index.js
+++ b/run/tasks/lint/index.js
@@ -12,11 +12,13 @@ var gulp = require('gulp'),
     args = require('yargs').argv,
     chalk = require('chalk'),
     common = require('./_common'),
+    debug = require('gulp-debug'),
     jshint = require('gulp-jshint');
 
 gulp.task('lint', function() {
     return gulp.src(common.buildSources(args.filePath))
         .pipe(jshint())
+        .pipe(debug({ title: 'Lint:' }))
         .pipe(jshint.reporter('jshint-stylish'))
         .pipe(jshint.reporter('fail'))
         .on('error', function() {


### PR DESCRIPTION
Lint / JSCS output was virtually nothing if there were no errors, making users wonder if it ran at all. This will show the files being scanned to prove it has worked.