### PR TITLE
Fixing CSS Sourcemaps.

### DIFF
--- a/run/tasks/styles/_common.js
+++ b/run/tasks/styles/_common.js
@@ -19,8 +19,9 @@ module.exports = {
     outputFolder: './css/',
 
     // Settings to be passed through to gulp-sass and node-sass.
+    // Note: `compact` is used over `compressed` due to a sourcemaps bug.
     sassSettings: {
-        outputStyle: 'compressed'
+        outputStyle: 'compact'
     },
 
     // Settings for AutoPrefixer.


### PR DESCRIPTION
Fixing sourcemaps by using a different output style. It's a strange bug with no real sign of surfacing on any of the issue trackers for `gulp-sass`, `gulp-autoprefixer` or `libsass` but the fix is trivial enough and doesn't impact our output file sizes too much.