### PR TITLE
Linting: DRY variables.

### DIFF
--- a/run/_global.js
+++ b/run/_global.js
@@ -3,36 +3,59 @@
 module.exports = {
 
     /**
-     *  Where built output (CSS, JS, HTML, fonts, images) should be stored
-     *  on the filesystem. Can either be an absolute path or relative path
-     *  to the location of the gulpfile.
+     * Locations of JavaScript source files. This array is used in
+     * conjunction with linting and jscs tasks (keeping things DRY).
+     * Paths should be relative to the top-level gulpfile.
+     *
+     * @type {Array}
      */
-    destPath: './dist/',
+    scriptSourcePaths: ['./js/src/**/*.js'],
 
+    /**
+     * Settings for sourcemaps across JS and CSS bundles.
+     *
+     * @type {Object}
+     */
     sourcemapOptions: {
 
         /**
-         *  Sourcemaps are built externally but there is two choices. Source
-         *  files can be embedded inside the map itself, or, the source files
-         *  can be referenced by the map and loaded whenever you try to click
-         *  line numbers in your dev tools.
+         * Sourcemaps are built externally but there is two choices.
+         * Source files can be embedded inside the map itself, or,
+         * the source files can be referenced by the map and loaded
+         * whenever you try to click line numbers in your dev tools.
          *
-         *  Potential Values:
-         *  'External_EmbeddedFiles'
-         *  'External_ReferencedFiles'
+         * If your source files are not being served via a web server
+         * then stick to using `External_EmbeddedFiles`.
+         *
+         * Potential Values:
+         * 'External_EmbeddedFiles'
+         * 'External_ReferencedFiles'
+         *
+         * @type {String}
          */
         type: 'External_EmbeddedFiles',
 
         /**
-         *  Sets the path where source files are hosted. This path is relative
-         *  to the source map. If you have sources in different subpaths, an
-         *  absolute path (from the domain root) pointing to the source file
-         *  root is recommended.
+         * Sets the root path of where source files are hosted. This
+         * path is relative to the source map. If you have sources in
+         * different subpaths, an absolute path (from the domain root)
+         * pointing to the source file root is recommended.
          *
-         *  NOTE: This only needs to be set for 'External_ReferencedFiles' maps.
+         * NOTE: Only needs to be set for 'External_ReferencedFiles'.
+         *
+         * @type {String}
          */
         sourceRoot: '/'
 
-    }
+    },
+
+    /**
+     * Where built output (CSS, JS, HTML, fonts, images) should be
+     * stored on the filesystem. Can either be an absolute path or
+     * relative path to the location of the gulpfile.
+     *
+     * @type {String}
+     */
+    destPath: './dist/'
 
 };

--- a/run/tasks/jscs/_common.js
+++ b/run/tasks/jscs/_common.js
@@ -1,13 +1,13 @@
 'use strict';
 
-module.exports = {
-    srcPaths: ['./js/src/**/*.js'],
+var globalSettings = require('../../_global');
 
+module.exports = {
     /**
      *  Sets paths to be as specified else falls back to defaults.
      *
-     *  @param string specifiedPath - Path of JS files relative to root.
-     *  @return array
+     *  @param {String} specifiedPath - Path of JS files relative to root.
+     *  @return {Array}
      */
     buildSources: function(specifiedPath) {
         var sourceList = [];
@@ -15,7 +15,7 @@ module.exports = {
         if (specifiedPath) {
             sourceList.push(specifiedPath);
         } else {
-            sourceList = this.srcPaths;
+            sourceList = globalSettings.scriptSourcePaths;
         }
 
         return sourceList;

--- a/run/tasks/jscs/index.js
+++ b/run/tasks/jscs/index.js
@@ -2,15 +2,13 @@
 
 /**
  *  Checks chosen JS source files and reports any errors.
+ *  Configure via `.jscsrc` file in project root.
  *
  *  NOTE: JSCS is not a linter; it enforces coding style only and
  *  doesn't check for coding errors, abnormalities or misuse.
  *
  *  Potential Options:
  *  http://jscs.info/rules.html
- *
- *  Current options based upon Google preset:
- *  https://github.com/jscs-dev/node-jscs/blob/master/presets/google.json
  *
  *  Example Usage:
  *  gulp jscs

--- a/run/tasks/lint/_common.js
+++ b/run/tasks/lint/_common.js
@@ -1,13 +1,13 @@
 'use strict';
 
-module.exports = {
-    srcPaths: ['./js/src/**/*.js'],
+var globalSettings = require('../../_global');
 
+module.exports = {
     /**
      *  Sets paths to be as specified else falls back to defaults.
      *
-     *  @param string specifiedPath - Path of JS files relative to root.
-     *  @return array
+     *  @param {String} specifiedPath - Path of JS files relative to root.
+     *  @return {Array}
      */
     buildSources: function(specifiedPath) {
         var sourceList = [];
@@ -15,7 +15,7 @@ module.exports = {
         if (specifiedPath) {
             sourceList.push(specifiedPath);
         } else {
-            sourceList = this.srcPaths;
+            sourceList = globalSettings.scriptSourcePaths;
         }
 
         return sourceList;

--- a/run/tasks/lint/index.js
+++ b/run/tasks/lint/index.js
@@ -2,6 +2,7 @@
 
 /**
  *  Lints chosen source files and reports any errors.
+ *  Configure via `.jshintrc` file in project root.
  *
  *  Example Usage:
  *  gulp lint


### PR DESCRIPTION
- Cleaning up the global settings file to adhere to JSCS/Linting conventions.
- Updating JSCS and Lint tasks to use the same path configuration variable.