### PR TITLE
Removing ES6 Promise Polyfill.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,7 +28,6 @@
     "precommit-hook": "^3.0.0",
     "chalk": "^1.1.0",
     "yargs": "^3.15.0",
-    "es6-promise": "^2.3.0",
     "underscore": "^1.8.3",
     "gulp": "^3.9.0",
     "gulp-debug": "^2.1.0",

--- a/run/index.js
+++ b/run/index.js
@@ -1,8 +1,5 @@
 'use strict';
 
-// Adding promises to nodes global scope.
-require('es6-promise').polyfill();
-
 /**
  *  Acts as an override for module loading. Certain modules
  *  need to load modules other than themselves to function.


### PR DESCRIPTION
Removing ES6 promise polyfill now that chromium version of node under the hood is recent enough to support them natively.