### PR TITLE
Pre-Commit Hook Removal

### DIFF
--- a/README.md
+++ b/README.md
@@ -197,8 +197,3 @@ Compiles SASS into CSS and autoprefixes where applicable.
 ### `test`
 Runs the test runner and any tests within the front-end tests folder. Also
 outputs JUnit XML for Jenkins.
-
-
-### SourceTree
-In case you use sourcetree you need to open through Terminal, with command :
-`open /Applications/SourceTree.app/Contents/MacOS/SourceTree` , otherwise the pre-commit hook will lok the software

--- a/package.json
+++ b/package.json
@@ -14,16 +14,9 @@
   ],
   "scripts": {
     "gulp": "gulp",
-    "postinstall": "gulp build --is-production",
-    "lint": "gulp lint && gulp jscs",
-    "jscs-via-commit": "gulp jscs --via-commit",
-    "lint-via-commit": "gulp lint --via-commit",
-    "validate": "gulp jscs --via-commit && gulp lint --via-commit"
+    "lint": "gulp lint",
+    "postinstall": "gulp build --is-production"
   },
-  "pre-commit": [
-    "jscs-via-commit",
-    "lint-via-commit"
-  ],
   "dependencies": {},
   "devDependencies": {
     "babel-core": "6.1.2",
@@ -42,7 +35,6 @@
     "gulp-sourcemaps": "1.5.2",
     "gulp-webserver": "0.9.1",
     "jshint-stylish": "2.0.1",
-    "precommit-hook": "3.0.0",
     "webpack-stream": "2.1.1",
     "yargs": "3.15.0"
   }

--- a/run/tasks/jscs/index.js
+++ b/run/tasks/jscs/index.js
@@ -27,12 +27,5 @@ gulp.task('jscs', function() {
 
     return gulp.src(sourceFiles)
         .pipe(debug({title: 'JSCS:'}))
-        .pipe(jscs())
-        .on('error', function() {
-            if (args.viaCommit) {
-                setTimeout(function() {
-                    console.log(chalk.bgRed.white('\n FE Skeleton: Your commit failed! Fix errors then re-commit.'));
-                }, 0);
-            }
-        });
+        .pipe(jscs());
 });

--- a/run/tasks/jshint/index.js
+++ b/run/tasks/jshint/index.js
@@ -26,12 +26,5 @@ gulp.task('jshint', function() {
         .pipe(jshint())
         .pipe(debug({title: 'Lint:'}))
         .pipe(jshint.reporter('jshint-stylish'))
-        .pipe(jshint.reporter('fail'))
-        .on('error', function() {
-            if (args.viaCommit) {
-                setTimeout(function() {
-                    console.log(chalk.bgRed.white('\n FE Skeleton: Your commit failed! Fix errors then re-commit.'));
-                }, 0);
-            }
-        });
+        .pipe(jshint.reporter('fail'));
 });


### PR DESCRIPTION
The commit hook is becoming no longer necessary; the development team is more aware of the standards we need to keep. There's been multiple discussions around the topic amongst the team at various levels and that's given the topic more prominence. We now have our jenkins cluster set up and ready for project integrations.

The miyagi team have standards, linting, formatting and unit testing as part of their everyday workflow and once these team members disperse onto new projects, hopefully they'll take their regimented workflow with them. We have to entrust the lead developers on the project to keep code conforming to the rules and ensure that unit tests are being written.