### PR TITLE
Add eslint rule: spaces should follow commas

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,7 +25,7 @@
     "brace-style": 2,
     "camelcase": 2,
     "comma-dangle": 2,
-    "comma-spacing": [2, { "before": false, "after": true }],
+    "comma-spacing": [2, {"before": false, "after": true}],
     "comma-style": 2,
     "computed-property-spacing": [2, "never"],
     "curly": 2,

--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -25,6 +25,7 @@
     "brace-style": 2,
     "camelcase": 2,
     "comma-dangle": 2,
+    "comma-spacing": [2, { "before": false, "after": true }],
     "comma-style": 2,
     "computed-property-spacing": [2, "never"],
     "curly": 2,


### PR DESCRIPTION
`foo('apple', 'banana', ['orange', 'grape', 'melon'])`  

and not 

`foo('apple','banana',['orange','grape','melon'])`