### PR TITLE
Test Suite: Code Coverage

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -224,8 +224,7 @@ sftp-config.json
 docs/_build/doctrees/environment.pickle
 
 # Output by junit/cobertura via Karma for integration with Jenkins.
-test-results/results.xml
-fe-coverage-results.xml
+test-results/
 
 # Default destination for image minification.
 img-min

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -4,8 +4,17 @@
 var args = require('yargs').argv,
     globalSettings = require('./run/config');
 
-// Bind a shorter reference to the script settings from the global file.
-var scriptSettings = globalSettings.taskConfiguration.scripts;
+// Bind a shorter reference to the webpack settings from the global file.
+var webpackSettings = globalSettings.taskConfiguration.scripts.webpackSettings;
+
+// Add istanbul code coverage specific settings to the webpack config
+webpackSettings.module.preLoaders = [
+    {
+        test: /\.js$/,
+        exclude: /(node_modules|spec\.js$|run\/tasks\/test\/wrapper\.js)/,
+        loader: 'istanbul-instrumenter'
+    }
+];
 
 // Setting variables for upcoming checks and use in karma settings.
 var autoWatch,
@@ -69,7 +78,7 @@ module.exports = function(config) {
          *
          * @type {Object}
          */
-        webpack: scriptSettings.webpackSettings,
+        webpack: webpackSettings,
 
         /**
          * After a change the watcher waits for more changes.
@@ -84,12 +93,29 @@ module.exports = function(config) {
             }
         },
 
-        reporters: ['progress', 'junit'],
+        reporters: [
+            'progress',
+            'junit',
+            'coverage'
+        ],
 
         junitReporter: {
             outputDir: './test-results',
             outputFile: 'results.xml',
             useBrowserName: false
+        },
+
+        coverageReporter: {
+            dir: './test-results',
+            reporters: [
+                {
+                    type: 'html',
+                    subdir: 'html'
+                },
+                {
+                    type: 'text-summary'
+                }
+            ]
         },
 
         browsers: ['PhantomJS'],

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,6 +7,9 @@ var args = require('yargs').argv,
 // Bind a shorter reference to the webpack settings from the global file.
 var webpackSettings = globalSettings.taskConfiguration.scripts.webpackSettings;
 
+// Ensure that any entry bundles pre-defined in the config are forgotten about.
+webpackSettings.entry = {};
+
 // Add babel-istanbul code coverage specific settings to the webpack config.
 webpackSettings.module.loaders.push(
     {

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -117,6 +117,11 @@ module.exports = function(config) {
                 },
                 {
                     type: 'text-summary'
+                },
+                {
+                    type: 'cobertura',
+                    subdir: 'cobertura',
+                    file: 'cobertura.xml'
                 }
             ]
         },

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -7,14 +7,17 @@ var args = require('yargs').argv,
 // Bind a shorter reference to the webpack settings from the global file.
 var webpackSettings = globalSettings.taskConfiguration.scripts.webpackSettings;
 
-// Add istanbul code coverage specific settings to the webpack config
-webpackSettings.module.preLoaders = [
+// Add babel-istanbul code coverage specific settings to the webpack config.
+webpackSettings.module.loaders.push(
     {
         test: /\.js$/,
-        exclude: /(node_modules|spec\.js$|run\/tasks\/test\/wrapper\.js)/,
-        loader: 'istanbul-instrumenter'
+        exclude: /(node_modules|bower_components|spec\.js$|run\/tasks\/test\/wrapper\.js)/,
+        loader: 'babel-istanbul',
+        query: {
+            cacheDirectory: true
+        }
     }
-];
+);
 
 // Setting variables for upcoming checks and use in karma settings.
 var autoWatch,

--- a/karma.conf.js
+++ b/karma.conf.js
@@ -12,10 +12,7 @@ webpackSettings.module.loaders.push(
     {
         test: /\.js$/,
         exclude: /(node_modules|bower_components|spec\.js$|run\/tasks\/test\/wrapper\.js)/,
-        loader: 'babel-istanbul',
-        query: {
-            cacheDirectory: true
-        }
+        loader: 'babel-istanbul'
     }
 );
 

--- a/package.json
+++ b/package.json
@@ -21,6 +21,7 @@
   },
   "dependencies": {},
   "devDependencies": {
+    "babel-istanbul-loader": "0.1.0",
     "babel-core": "6.1.2",
     "babel-loader": "6.0.1",
     "babel-preset-es2015": "6.1.2",

--- a/run/config.js
+++ b/run/config.js
@@ -180,7 +180,14 @@ module.exports = {
                 },
                 module: {
                     loaders: [
-                        {test: /\.js$/, exclude: /(node_modules|bower_components)/, loader: 'babel?presets[]=es2015'}
+                        {
+                            test: /\.js$/,
+                            exclude: /(node_modules|bower_components|run\/tasks\/test\/wrapper\.js)/,
+                            loader: 'babel',
+                            query: {
+                                presets: ['es2015']
+                            }
+                        }
                     ]
                 },
                 plugins: [


### PR DESCRIPTION
Uses `babel-istanbul` and `karma-coverage` to add code coverage information in the form of Cobertura XML that can be used by Jenkins.