### PR TITLE
Adding copy and clean tasks.

### DIFF
--- a/package.json
+++ b/package.json
@@ -28,6 +28,7 @@
     "browser-sync": "2.12.5",
     "browser-sync-webpack-plugin": "1.0.1",
     "chalk": "1.1.0",
+    "del": "2.2.1",
     "gulp": "3.9.0",
     "gulp-autoprefixer": "2.3.1",
     "gulp-debug": "2.1.0",
@@ -37,6 +38,7 @@
     "gulp-rename": "1.2.2",
     "gulp-sass": "2.0.3",
     "gulp-sourcemaps": "1.5.2",
+    "run-sequence": "1.2.2",
     "webpack-stream": "2.1.1",
     "yargs": "3.15.0"
   }

--- a/run/config.js
+++ b/run/config.js
@@ -57,7 +57,16 @@ module.exports = {
      */
     taskConfiguration: {
         build: {
+        },
+        copy: {
             sourcePaths: ['./fonts/**/!(dir.txt)', './web-manifest.json']
+        },
+        clean: {
+            additionalTargetPaths: [
+                './test-results/'
+            ],
+            delOptions: {
+            }
         },
         html: {
             sourcePaths: ['./html/**/*.html']

--- a/run/index.js
+++ b/run/index.js
@@ -7,9 +7,9 @@
  * @type {Object}
  */
 var loadingOverrides = {
-    'build': ['html', 'images', 'styles', 'scripts', 'build'],
-    'default': ['html', 'images', 'styles', 'scripts', 'build', 'default'],
-    'watch': ['html', 'images', 'styles', 'scripts', 'build', 'watch']
+    'build': ['clean', 'copy', 'html', 'images', 'styles', 'scripts', 'build'],
+    'default': ['clean', 'copy', 'html', 'images', 'styles', 'scripts', 'build', 'default'],
+    'watch': ['clean', 'copy', 'html', 'images', 'styles', 'scripts', 'build', 'watch']
 };
 
 /**

--- a/run/tasks/build/index.js
+++ b/run/tasks/build/index.js
@@ -1,9 +1,8 @@
 'use strict';
 
 /**
- * Builds all necessary front-end static files and moves fonts
- * into the distribution folder also. This method is primarily
- * used during deployment or initial setup.
+ * Builds all necessary front-end static files into the distribution folder.
+ * This method is primarily used during deployment or initial setup.
  *
  * Example Usage:
  * gulp build
@@ -11,17 +10,19 @@
 
 var gulp = require('gulp');
 var chalk = require('chalk');
+var runSequence = require('run-sequence');
 var globalSettings = require('../../config');
 
-gulp.task('build', ['html', 'images', 'styles', 'scripts'], function() {
-    if (Object.keys(globalSettings.taskConfiguration.scripts.webpackSettings.entry).length === 0) {
-        console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no script bundles defined.'));
-    }
+gulp.task('build', function(done) {
+    runSequence('clean', ['copy', 'html', 'images', 'styles', 'scripts'], function() {
+        if (Object.keys(globalSettings.taskConfiguration.scripts.webpackSettings.entry).length === 0) {
+            console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no script bundles defined.'));
+        }
 
-    if (globalSettings.taskConfiguration.styles.bundles.length === 0) {
-        console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no style bundles defined.'));
-    }
+        if (globalSettings.taskConfiguration.styles.bundles.length === 0) {
+            console.log(chalk.bgYellow.gray(' FE Skeleton: Warning - There are no style bundles defined.'));
+        }
 
-    return gulp.src(globalSettings.taskConfiguration.build.sourcePaths, {base: './'})
-               .pipe(gulp.dest(globalSettings.destPath));
+        done();
+    });
 });

--- a/run/tasks/clean/index.js
+++ b/run/tasks/clean/index.js
@@ -1,0 +1,29 @@
+'use strict';
+
+/**
+ * Removes a collection of specified directory paths (includes `destPath`) in
+ * preparation for new build files being created and placed. It ensures if
+ * there's been any change in configuration (i.e. file names) that old files
+ * will be cleaned up.
+ *
+ * Example Usage:
+ * gulp clean
+ */
+
+var gulp = require('gulp');
+var chalk = require('chalk');
+var globalSettings = require('../../config');
+var del = require('del');
+
+gulp.task('clean', function() {
+    var targetPaths = [globalSettings.destPath];
+
+    targetPaths = targetPaths.concat(globalSettings.taskConfiguration.clean.additionalTargetPaths);
+
+    return del(
+        targetPaths,
+        globalSettings.taskConfiguration.clean.delOptions
+    ).then(function(paths) {
+        console.log(chalk.bgGreen.white(' FE Skeleton: Folders Cleaned - ', paths.join('\n')));
+    });
+});

--- a/run/tasks/copy/index.js
+++ b/run/tasks/copy/index.js
@@ -1,0 +1,16 @@
+'use strict';
+
+/**
+ * Copies a set of desired assets into the distribution folder.
+ *
+ * Example Usage:
+ * gulp copy
+ */
+
+var gulp = require('gulp');
+var globalSettings = require('../../config');
+
+gulp.task('copy', function() {
+    return gulp.src(globalSettings.taskConfiguration.copy.sourcePaths, {base: './'})
+               .pipe(gulp.dest(globalSettings.destPath));
+});


### PR DESCRIPTION
Build Task:
* Now uses `run-sequence` npm module to ensure that `clean` task is run first, before all the other build tasks run in parallel (`styles`, `html`, `scripts`, `images`, `copy`).

Copy Task (NEW):
* Contains the copy logic that used to be in the build task. The build task is now essentially logicless with all build processes having their own gulp task.

Clean Task (NEW):
* Removes `./test-results/` and `./dist/` before performing a build. This ensures old assets (such as old images, or files who have had their source file renamed) will be removed correctly.