### PR TITLE
Task Loading

### DIFF
--- a/run/index.js
+++ b/run/index.js
@@ -1,28 +1,11 @@
 'use strict';
 
 /**
- * Acts as an override for module loading. Certain modules
- * need to load modules other than themselves to function.
- *
- * @type {Object}
- */
-var loadingOverrides = {
-    'build': ['clean', 'copy', 'html', 'images', 'styles', 'scripts', 'build'],
-    'default': ['clean', 'copy', 'html', 'images', 'styles', 'scripts', 'build', 'default'],
-    'watch': ['clean', 'copy', 'html', 'images', 'styles', 'scripts', 'build', 'watch']
-};
-
-/**
- * Acts as a module loader which gives us the ability to override certain
- * tasks and load more modules or a totally different set of modules.
+ * Loads the relevant modularised task that the user has requested.
  */
 module.exports = function() {
     var args = require('yargs').argv;
     var desiredModule = (args._[0] || 'default');
-    var modulesToLoad = loadingOverrides[desiredModule] || [desiredModule];
 
-    modulesToLoad.forEach(function(module) {
-        console.log(' FE Skeleton: Loading module - ' + module);
-        require('./tasks/' + module + '/');
-    });
+    require('./tasks/' + desiredModule + '/');
 };

--- a/run/tasks/build/index.js
+++ b/run/tasks/build/index.js
@@ -8,6 +8,13 @@
  * gulp build
  */
 
+require('../clean/');
+require('../copy/');
+require('../html/');
+require('../images/');
+require('../styles/');
+require('../scripts/');
+
 var gulp = require('gulp');
 var chalk = require('chalk');
 var runSequence = require('run-sequence');

--- a/run/tasks/default/index.js
+++ b/run/tasks/default/index.js
@@ -7,6 +7,8 @@
  * gulp
  */
 
+require('../build/');
+
 var gulp = require('gulp');
 
 gulp.task('default', function() {

--- a/run/tasks/watch/index.js
+++ b/run/tasks/watch/index.js
@@ -12,6 +12,8 @@
  * gulp watch --watchType styles,html
  */
 
+require('../build/');
+
 var gulp = require('gulp');
 var args = require('yargs').argv;
 var chalk = require('chalk');


### PR DESCRIPTION
Currently the `index.js` for the task runner has it's own override map to ensure that if you load `build` or other high-level tasks, that it also a bunch of other tasks beforehand. This is probably better kept with each of the tasks themselves and treated like dependencies. I don't see any use in separating these dependencies and storing them somewhere other than the tasks themselves.