### PR TITLE
Fixing switch statement indentation.

### DIFF
--- a/.eslintrc.json
+++ b/.eslintrc.json
@@ -32,7 +32,7 @@
     "dot-notation": 2,
     "eol-last": 2,
     "eqeqeq": [2, "allow-null"],
-    "indent": [2, 4],
+    "indent": [2, 4, {"SwitchCase": 1}],
     "key-spacing": 2,
     "keyword-spacing": [2, {"before": true, "after": true}],
     "max-len": [2, {"code": 120, "ignoreComments": true, "ignoreUrls": true}],


### PR DESCRIPTION
Indentation rules are currently forcing switch statements to look like this:
```
switch(testVar) {
case 'hello':
    console.log('world');
    break;
}
```

Which is an oversight; it should allow for normal indentation like this:
```
switch(testVar) {
    case 'hello':
        console.log('world');
        break;
}
```